### PR TITLE
Normalize graph peaks at the end of the song chart.

### DIFF
--- a/SongChartVisualizer/UI/ViewControllers/ChartViewController.cs
+++ b/SongChartVisualizer/UI/ViewControllers/ChartViewController.cs
@@ -248,7 +248,20 @@ namespace SongChartVisualizer.UI.ViewControllers
 					continue;
 				}
 
-				var nps = tempNoteCount / (notes[i].time - startingTime);
+				var nps = 0f;
+				if (tempNoteCount >= 25)
+				{
+					nps = tempNoteCount / (notes[i].time - startingTime);
+				}
+				else // end of a map or a map with notes.Coint < 25
+				{
+					// if total notes count < 25 - do the usual way
+					// if there are more than 25 notes - try to normalize nps with data from tempNoteCount and (25 - tempNoteCount) notes from a section before
+					nps = notes.Count < 25
+						? tempNoteCount / (notes[i].time - notes[0].time)
+						: 25 / (notes[i].time - notes[i - 25].time);
+				}
+
 				if (!float.IsInfinity(nps))
 				{
 					npsSections.Add(new NpsInfo(nps, startingTime, notes[i].time));


### PR DESCRIPTION
An attempt to minimize graph peaks like the one below:
![image](https://user-images.githubusercontent.com/89227135/134075043-857b9f0d-f207-4e29-9047-c5ae55b480f5.png)
In case if last chunk contains a few of notes, add several notes from a previous chuck to normalize NPS.

Graph from the map above would be looks like this:
![image](https://user-images.githubusercontent.com/89227135/134075443-34b46f84-dbd3-456a-8b9c-4022a15d96ba.png)

An original peak was caused by the stack notes.
![image](https://user-images.githubusercontent.com/89227135/134075771-0d7a50ba-1bc5-4c5d-bc6a-52dca9e46e07.png)
